### PR TITLE
FOGL-5747 Fixes for requirements

### DIFF
--- a/check-0.15.2_CMakeLists.txt.patch
+++ b/check-0.15.2_CMakeLists.txt.patch
@@ -1,0 +1,12 @@
+--- CMakeLists.txt	2021-04-27 14:35:52.359863999 +0530
++++ CMakeLists.txt.updated	2021-04-27 14:26:16.551912000 +0530
+@@ -248,7 +248,9 @@
+   check_c_compiler_flag("-pthread" HAVE_PTHREADS_FLAG)
+   if (HAVE_PTHREADS_FLAG)
+     add_definitions("-pthread")
+-    add_link_options("-pthread")
++    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pthread")
++    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
++    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+   endif()
+ endif()

--- a/requirements.sh
+++ b/requirements.sh
@@ -37,10 +37,10 @@ fi
 git clone https://github.com/libexpat/libexpat.git
 (
 	cd libexpat/expat
-	rm -f CMakeCache.txt
-	mkdir -p build
-	cd build
-	cmake -D CMAKE_INSTALL_PREFIX=/usr/local -D EXPAT_BUILD_PKGCONFIG=ON -D EXPAT_ENABLE_INSTALL=ON -D EXPAT_SHARED_LIBS=ON .. && make -j4 && sudo make install
+	./buildconf.sh && \
+	./configure && \
+	make && \
+	make install
 )
 
 # libcheck:

--- a/requirements.sh
+++ b/requirements.sh
@@ -40,7 +40,7 @@ git clone https://github.com/libexpat/libexpat.git
 	./buildconf.sh && \
 	./configure && \
 	make && \
-	make install
+	sudo make install
 )
 
 # libcheck:


### PR DESCRIPTION
Add missing patch file and move building of libexpat to use configure rather than CMake as CMake has recently stopped working on Linux with this project.