### PR TITLE
Fogl 6049.patch - Requirements fixes and other cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build
+
+# Requirements
+S2OPC
+check-0.15.2.tar.gz
+check-0.15.2
+include/sopc_encodeabletype.h
+libexpat

--- a/Package
+++ b/Package
@@ -3,7 +3,7 @@
 plugin_name=s2opcua
 plugin_type=south
 plugin_install_dirname=${plugin_name}
-additional_libs="usr/local/lib:/usr/local/lib/libs2opc_common.so,usr/local/lib:/usr/local/lib/libs2opc_clientserver.so,usr/local/lib:/usr/local/lib/libs2opc_clientwrapper.so,usr/local/lib:/usr/local/lib/libexpat.so.1"
+additional_libs="usr/local/lib:/usr/local/lib/libs2opc_common.a,usr/local/lib:/usr/local/lib/libs2opc_clientserver.a,usr/local/lib:/usr/local/lib/libs2opc_clientwrapper.a,usr/local/lib:/usr/local/lib/libexpat.so.1"
 # Now build up the runtime requirements list. This has 3 components
 #   1. Generic packages we depend on in all architectures and package managers
 #   2. Architecture specific packages we depend on

--- a/cleanup
+++ b/cleanup
@@ -6,7 +6,7 @@ read continue
 if [ "$continue" != 'YES' ]; then
     echo Cleanup not done
 else
-    rm -rf check-0.15.2 && rm check-0.15.2.tar.gz* && rm -rf S2OPC && rm -rf libexpat
+    rm -rf check-0.15.2 && rm -rf check-0.15.2.tar.gz* && rm -rf S2OPC && rm -rf libexpat && rm -rf include/sopc_encodeabletype.h
     echo Cleanup completed
 fi
 

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-##--------------------------------------------------------------------
-## Copyright (c) 2021 Dianomic Systems
+##---------------------------------------------------------------------------
+## Copyright (c) 2022 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##--------------------------------------------------------------------
+##---------------------------------------------------------------------------
 
 ##
 ## Author: Amandeep Singh Arora, Mark Riddoch
@@ -46,7 +46,7 @@ wget https://github.com/libcheck/check/releases/download/0.15.2/check-0.15.2.tar
 tar xf check-0.15.2.tar.gz
 (
 	cd check-0.15.2
-	cp ../fledge-south-s2opcua/check-0.15.2_CMakeLists.txt.patch .
+	cp ../check-0.15.2_CMakeLists.txt.patch .
 	patch < check-0.15.2_CMakeLists.txt.patch  # update the CMakeLists.txt file
 	rm -f CMakeCache.txt
 	mkdir -p build
@@ -58,8 +58,8 @@ tar xf check-0.15.2.tar.gz
 git clone https://gitlab.com/systerel/S2OPC.git
 (
 	cd S2OPC
-	cp ./src/Common/opcua_types/sopc_encodeabletype.h ../fledge-south-s2opcua/include
-	ed ../fledge-south-s2opcua/include/sopc_encodeabletype.h << EOED
+	cp ./src/Common/opcua_types/sopc_encodeabletype.h ../include
+	ed ../include/sopc_encodeabletype.h << EOED
 ,s/typedef const struct SOPC_EncodeableType/typedef struct SOPC_EncodeableType/1
 w
 q


### PR DESCRIPTION
Compilation of this plugin is still failing with develop branch and packages are not available in nightly builds. http://archives.fledge-iot.org/nightly

With the given change I am able to see the compilation successfully on fresh machines. And also make the discovery plugin with Package installation

- [x] ub18
- [x] ub20
- [x] raspberry4+buster

Here are the custom Packages with given change - http://archives.fledge-iot.org/fixes/FOGL-6049