### PR TITLE
FOGL-6675: Removed workaround of editing an S2OPC include file

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -60,12 +60,6 @@ git clone https://gitlab.com/systerel/S2OPC.git
 	cd S2OPC
 	cp ../S2OPC.patch .
 	git apply S2OPC.patch
-	cp ./src/Common/opcua_types/sopc_encodeabletype.h ../include
-	ed ../include/sopc_encodeabletype.h << EOED
-,s/typedef const struct SOPC_EncodeableType/typedef struct SOPC_EncodeableType/1
-w
-q
-EOED
 	BUILD_SHARED_LIBS=OFF
 	CMAKE_INSTALL_PREFIX=/usr/local
 	./build.sh


### PR DESCRIPTION
Because of a change in the S2OPC Toolkit, the toolkit became incompatible with C++. This was reported to Systerel as [Issue #943](https://gitlab.com/systerel/S2OPC/-/issues/943). A workaround was created which involved editing an S2OPC include file to avoid compilation errors. The problem has been resolved by Systerel so the workaround is no longer necessary.

Signed-off-by: Ray Verhoeff <ray@dianomic.com>