### PR TITLE
FOGL-6675A: Update for S2OPCUA Toolkit 1.2.0

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -55,7 +55,7 @@ tar xf check-0.15.2.tar.gz
 )
 
 # S2OPC
-git clone https://gitlab.com/systerel/S2OPC.git --branch S2OPC_Toolkit_1.2.0
+git clone https://gitlab.com/systerel/S2OPC.git --branch S2OPC_Toolkit_1.2.0 --depth 1
 (
 	cd S2OPC
 	cp ../S2OPC.patch .

--- a/requirements.sh
+++ b/requirements.sh
@@ -55,7 +55,7 @@ tar xf check-0.15.2.tar.gz
 )
 
 # S2OPC
-git clone https://gitlab.com/systerel/S2OPC.git
+git clone https://gitlab.com/systerel/S2OPC.git --branch S2OPC_Toolkit_1.2.0
 (
 	cd S2OPC
 	cp ../S2OPC.patch .


### PR DESCRIPTION
Systerel has released S2OPCUA Toolkit Version 1.2.0. They created the GitLab tag [S2OPC_Toolkit_1.2.0](https://gitlab.com/systerel/S2OPC/-/releases/S2OPC_Toolkit_1.2.0) to allow partners to clone the [S2OPC repository](https://gitlab.com/systerel/S2OPC) from the released version. This pull request updates requirements.sh to clone the S2OPC 1.2.0 release.

Signed-off-by: Ray Verhoeff <ray@dianomic.com>