### PR TITLE
FOGL-7849A: Support for large numbers of Monitored Items

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ To build S2OPC and its dependencies:
 .. code-block:: console
 
   $ cd ~/dev
-  $ git clone https://gitlab.com/systerel/S2OPC.git
+  $ git clone https://gitlab.com/systerel/S2OPC.git --branch S2OPC_Toolkit_1.4.1 --depth 1
   $ git clone https://github.com/fledge-iot/fledge-south-s2opcua.git
   $ cd S2OPC
   $ cp ../fledge-south-s2opcua/S2OPC.patch .

--- a/S2OPC.patch
+++ b/S2OPC.patch
@@ -102,6 +102,19 @@ index 5d36fe1..8242a65 100644
          case SOPC_DateTime_Id:
          case SOPC_Guid_Id:
          case SOPC_XmlElement_Id:
+diff --git a/src/ClientServer/services/b2c/message_out_bs.c b/src/ClientServer/services/b2c/message_out_bs.c
+index 5caa845..02b068f 100644
+--- a/src/ClientServer/services/b2c/message_out_bs.c
++++ b/src/ClientServer/services/b2c/message_out_bs.c
+@@ -258,7 +258,7 @@ static void internal__message_out_bs__encode_msg(const constants__t_channel_conf
+             reqHeader = (OpcUa_RequestHeader*) message_out_bs__msg_header;
+             reqHeader->Timestamp = SOPC_Time_GetCurrentTimeUTC();
+             // TODO: reqHeader->AuditEntryId ?
+-            reqHeader->TimeoutHint = SOPC_REQUEST_TIMEOUT_MS / 2; // TODO: to be configured by each service ?
++            reqHeader->TimeoutHint = 0; // TODO: to be configured by each service ?
+         }
+         else if (&OpcUa_ResponseHeader_EncodeableType == headerType)
+         {
 diff --git a/src/Common/configuration/sopc_common_constants.h b/src/Common/configuration/sopc_common_constants.h
 index cd922b8..ca588e2 100644
 --- a/src/Common/configuration/sopc_common_constants.h

--- a/S2OPC.patch
+++ b/S2OPC.patch
@@ -1,5 +1,5 @@
 diff --git a/CommonDefs.cmake b/CommonDefs.cmake
-index 7cca75030..b22079425 100644
+index 6c8afe4..cfec07e 100644
 --- a/CommonDefs.cmake
 +++ b/CommonDefs.cmake
 @@ -29,8 +29,8 @@ endforeach(OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES)
@@ -14,7 +14,7 @@ index 7cca75030..b22079425 100644
    set(USE_STATIC_MBEDTLS_LIB ${USE_STATIC_EXT_LIBS})
    set(USE_STATIC_EXPAT_LIB ${USE_STATIC_EXT_LIBS})
 diff --git a/src/ClientServer/frontend/client_wrapper/libs2opc_client.h b/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
-index 693c63ab0..24c67dac2 100644
+index 81fcc29..5104966 100644
 --- a/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
 +++ b/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
 @@ -129,7 +129,9 @@ typedef enum
@@ -29,10 +29,18 @@ index 693c63ab0..24c67dac2 100644
  
  /**
 diff --git a/src/ClientServer/frontend/client_wrapper/state_machine.c b/src/ClientServer/frontend/client_wrapper/state_machine.c
-index 34fbdaa34..bdc2e2d7e 100644
+index 34fbdaa..9b75f78 100644
 --- a/src/ClientServer/frontend/client_wrapper/state_machine.c
 +++ b/src/ClientServer/frontend/client_wrapper/state_machine.c
-@@ -1288,10 +1288,12 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
+@@ -1263,7 +1263,6 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
+     /* Take note to acknowledge later. There is no ack with KeepAlive. */
+     /* TODO: this limits the benefits of having multiple pending PublishRequest, maybe
+      * it would be more appropriate to have a list of SeqNumbsToAck... */
+-    assert(!pSM->bAckSubscr);
+     if (0 < pPubResp->NoOfAvailableSequenceNumbers)
+     {
+         pSM->bAckSubscr = true;
+@@ -1288,10 +1287,12 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
          assert(SOPC_ExtObjBodyEncoding_Object == pNotifMsg->NotificationData[0].Encoding);
          assert(&OpcUa_DataChangeNotification_EncodeableType == pNotifMsg->NotificationData[0].Body.Object.ObjType);
          pDataNotif = (OpcUa_DataChangeNotification*) pNotifMsg->NotificationData[0].Body.Object.Value;
@@ -45,22 +53,28 @@ index 34fbdaa34..bdc2e2d7e 100644
              if (SOPC_STATUS_OK == status)
              {
                  if (NULL != pSM->pCbkLibSubDataChanged)
+@@ -1527,6 +1528,7 @@ static void StaMac_PostProcessActions(SOPC_StaMac_Machine* pSM, SOPC_StaMac_Stat
+     {
+     /* Mostly when stActivated is reached */
+     case stActivated:
++    case stCreatingMonIt:
+         /* add tokens, but wait for at least a monitored item */
+         if (0 != pSM->iSubscriptionID && pSM->nTokenUsable < pSM->nTokenTarget)
+         {
 diff --git a/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c b/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
-index e2fa388ff..b4babe046 100644
+index 93b265d..afdb775 100644
 --- a/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
 +++ b/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
-@@ -111,8 +111,8 @@ SOPC_ReturnStatus Helpers_NewSCConfigFromLibSubCfg(const char* szServerUrl,
-             status = SOPC_PKIProviderStack_CreateFromPaths(lPathsTrustedRoots, lPathsTrustedLinks, lPathsUntrustedRoots,
+@@ -118,7 +118,7 @@ SOPC_ReturnStatus Helpers_NewSCConfigFromLibSubCfg(const char* szServerUrl,
                                                             lPathsUntrustedLinks, lPathsIssuedCerts, lPathsCRL, &pPki);
              if (SOPC_STATUS_OK != status)
--            {
+             {
 -                Helpers_Log(SOPC_LOG_LEVEL_ERROR, "Failed to create PKI.");
-+            {
 +                Helpers_Log(SOPC_LOG_LEVEL_ERROR, "Failed to create PKI, status=%d", status);
              }
          }
          else
-@@ -536,9 +536,36 @@ SOPC_ReturnStatus Helpers_NewValueFromDataValue(SOPC_DataValue* pVal, SOPC_LibSu
+@@ -544,9 +544,36 @@ SOPC_ReturnStatus Helpers_NewValueFromDataValue(SOPC_DataValue* pVal, SOPC_LibSu
              }
              /* else we leave value NULL and length = 0 */
              break;
@@ -100,7 +114,7 @@ index e2fa388ff..b4babe046 100644
          case SOPC_Guid_Id:
          case SOPC_XmlElement_Id:
 diff --git a/src/Common/configuration/sopc_common_constants.h b/src/Common/configuration/sopc_common_constants.h
-index 874129c1e..9e24ed808 100644
+index f2da81b..ae0d666 100644
 --- a/src/Common/configuration/sopc_common_constants.h
 +++ b/src/Common/configuration/sopc_common_constants.h
 @@ -77,7 +77,7 @@ bool SOPC_Common_SetEncodingConstants(SOPC_Common_EncodingConstants config);

--- a/S2OPC.patch
+++ b/S2OPC.patch
@@ -1,5 +1,5 @@
 diff --git a/CommonDefs.cmake b/CommonDefs.cmake
-index 6c8afe4..cfec07e 100644
+index 70d788b..303ec86 100644
 --- a/CommonDefs.cmake
 +++ b/CommonDefs.cmake
 @@ -29,8 +29,8 @@ endforeach(OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES)
@@ -14,46 +14,41 @@ index 6c8afe4..cfec07e 100644
    set(USE_STATIC_MBEDTLS_LIB ${USE_STATIC_EXT_LIBS})
    set(USE_STATIC_EXPAT_LIB ${USE_STATIC_EXT_LIBS})
 diff --git a/src/ClientServer/frontend/client_wrapper/libs2opc_client.h b/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
-index 81fcc29..5104966 100644
+index 3c187fc..359240f 100644
 --- a/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
 +++ b/src/ClientServer/frontend/client_wrapper/libs2opc_client.h
-@@ -129,7 +129,9 @@ typedef enum
+@@ -131,7 +131,9 @@ typedef enum
      SOPC_LibSub_DataType_integer = 2,
      SOPC_LibSub_DataType_string = 3,
      SOPC_LibSub_DataType_bytestring = 4,
 -    SOPC_LibSub_DataType_other = 5
 +    SOPC_LibSub_DataType_float = 5,
-+	SOPC_LibSub_DataType_double = 6,
++    SOPC_LibSub_DataType_double = 6,
 +    SOPC_LibSub_DataType_other = 7
  } SOPC_LibSub_DataType;
  
  /**
 diff --git a/src/ClientServer/frontend/client_wrapper/state_machine.c b/src/ClientServer/frontend/client_wrapper/state_machine.c
-index 34fbdaa..9b75f78 100644
+index b45d556..0d3b595 100644
 --- a/src/ClientServer/frontend/client_wrapper/state_machine.c
 +++ b/src/ClientServer/frontend/client_wrapper/state_machine.c
-@@ -1263,7 +1263,6 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
+@@ -1373,7 +1373,6 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
      /* Take note to acknowledge later. There is no ack with KeepAlive. */
      /* TODO: this limits the benefits of having multiple pending PublishRequest, maybe
       * it would be more appropriate to have a list of SeqNumbsToAck... */
--    assert(!pSM->bAckSubscr);
+-    SOPC_ASSERT(!pSM->bAckSubscr);
      if (0 < pPubResp->NoOfAvailableSequenceNumbers)
      {
          pSM->bAckSubscr = true;
-@@ -1288,10 +1287,12 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
-         assert(SOPC_ExtObjBodyEncoding_Object == pNotifMsg->NotificationData[0].Encoding);
-         assert(&OpcUa_DataChangeNotification_EncodeableType == pNotifMsg->NotificationData[0].Body.Object.ObjType);
-         pDataNotif = (OpcUa_DataChangeNotification*) pNotifMsg->NotificationData[0].Body.Object.Value;
-+		Helpers_Log(SOPC_LOG_LEVEL_INFO, "%s:%d: pDataNotif->NoOfMonitoredItems=%d", "StaMac_ProcessMsg_PublishResponse", __LINE__, pDataNotif->NoOfMonitoredItems);
-         for (i = 0; i < pDataNotif->NoOfMonitoredItems; ++i)
+@@ -1402,6 +1401,7 @@ static void StaMac_ProcessMsg_PublishResponse(SOPC_StaMac_Machine* pSM, uint32_t
          {
              pMonItNotif = &pDataNotif->MonitoredItems[i];
              status = Helpers_NewValueFromDataValue(&pMonItNotif->Value, &plsVal);
-+			Helpers_Log(SOPC_LOG_LEVEL_INFO, "%s:%d: i=%d, plsVal->type=%d", "StaMac_ProcessMsg_PublishResponse", __LINE__, i, plsVal->type);
++            Helpers_Log(SOPC_LOG_LEVEL_INFO, "%s:%d: i=%d, plsVal->type=%d", "StaMac_ProcessMsg_PublishResponse", __LINE__, i, plsVal->type);
              if (SOPC_STATUS_OK == status)
              {
                  if (NULL != pSM->pCbkLibSubDataChanged)
-@@ -1527,6 +1528,7 @@ static void StaMac_PostProcessActions(SOPC_StaMac_Machine* pSM, SOPC_StaMac_Stat
+@@ -1637,6 +1637,7 @@ static void StaMac_PostProcessActions(SOPC_StaMac_Machine* pSM, SOPC_StaMac_Stat
      {
      /* Mostly when stActivated is reached */
      case stActivated:
@@ -62,10 +57,10 @@ index 34fbdaa..9b75f78 100644
          if (0 != pSM->iSubscriptionID && pSM->nTokenUsable < pSM->nTokenTarget)
          {
 diff --git a/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c b/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
-index 93b265d..afdb775 100644
+index 5d36fe1..8242a65 100644
 --- a/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
 +++ b/src/ClientServer/frontend/client_wrapper/toolkit_helpers.c
-@@ -118,7 +118,7 @@ SOPC_ReturnStatus Helpers_NewSCConfigFromLibSubCfg(const char* szServerUrl,
+@@ -120,7 +120,7 @@ SOPC_ReturnStatus Helpers_NewSCConfigFromLibSubCfg(const char* szServerUrl,
                                                             lPathsUntrustedLinks, lPathsIssuedCerts, lPathsCRL, &pPki);
              if (SOPC_STATUS_OK != status)
              {
@@ -74,12 +69,12 @@ index 93b265d..afdb775 100644
              }
          }
          else
-@@ -544,9 +544,36 @@ SOPC_ReturnStatus Helpers_NewValueFromDataValue(SOPC_DataValue* pVal, SOPC_LibSu
+@@ -602,9 +602,31 @@ SOPC_ReturnStatus Helpers_NewValueFromDataValue(SOPC_DataValue* pVal, SOPC_LibSu
              }
              /* else we leave value NULL and length = 0 */
              break;
-+
-+		case SOPC_Float_Id:
+-        case SOPC_Null_Id:
+         case SOPC_Float_Id:
 +            plsVal->type = SOPC_LibSub_DataType_float;
 +            plsVal->value = SOPC_Malloc(sizeof(float));
 +            if (NULL == plsVal->value)
@@ -91,8 +86,7 @@ index 93b265d..afdb775 100644
 +                *(float*) plsVal->value = (float) pVal->Value.Value.Floatv;
 +            }
 +            break;
-+
-+		case SOPC_Double_Id:
+         case SOPC_Double_Id:
 +            plsVal->type = SOPC_LibSub_DataType_double;
 +            plsVal->value = SOPC_Malloc(sizeof(double));
 +            if (NULL == plsVal->value)
@@ -104,17 +98,12 @@ index 93b265d..afdb775 100644
 +                *(double*) plsVal->value = (double) pVal->Value.Value.Doublev;
 +            }
 +            break;
-+
-         case SOPC_Null_Id:
--        case SOPC_Float_Id:
--        case SOPC_Double_Id:
-+        // case SOPC_Float_Id:
-+        // case SOPC_Double_Id:
++        case SOPC_Null_Id:
          case SOPC_DateTime_Id:
          case SOPC_Guid_Id:
          case SOPC_XmlElement_Id:
 diff --git a/src/Common/configuration/sopc_common_constants.h b/src/Common/configuration/sopc_common_constants.h
-index f2da81b..ae0d666 100644
+index cd922b8..ca588e2 100644
 --- a/src/Common/configuration/sopc_common_constants.h
 +++ b/src/Common/configuration/sopc_common_constants.h
 @@ -77,7 +77,7 @@ bool SOPC_Common_SetEncodingConstants(SOPC_Common_EncodingConstants config);

--- a/include/opcua.h
+++ b/include/opcua.h
@@ -88,6 +88,7 @@ class OPCUA
 	{
 		public:
 				Node(uint32_t connId, const std::string& nodeId);
+				Node(const std::string& nodeId, const std::string& BrowseName);
 				std::string	getBrowseName() { return m_browseName; };
 				uint32_t	getType() { return m_type; };
 				std::string	getNodeId() { return m_nodeID; };
@@ -123,7 +124,9 @@ class OPCUA
         std::mutex            	m_configMutex;
         std::atomic<bool>       m_connected;
         long                	m_reportingInterval;
-        
+        unsigned long           m_numOpcUaValues;
+        unsigned long           m_numOpcUaOverflows;
+
         std::string         	m_secPolicy;
         OpcUa_MessageSecurityMode m_secMode;
 

--- a/include/opcua.h
+++ b/include/opcua.h
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include <map>
+#include <set>
 extern "C" {
 #include "sopc_logger.h"
 #include "libs2opc_common_config.h"
@@ -107,7 +108,7 @@ class OPCUA
 	std::string		securityMode(OpcUa_MessageSecurityMode mode);
 	std::string		nodeClass(OpcUa_NodeClass nodeClass);
 	void			resolveDuplicateBrowseNames();
-	void			getParents();
+	// void			getParents();
 	int32_t			m_connectionId;
 	int32_t			m_configurationId;
         std::vector<std::string>
@@ -150,6 +151,7 @@ class OPCUA
 	char			*m_path_cert_cli;
 	char			*m_path_key_cli;
 	std::atomic<bool> m_stopped;
+	std::atomic<bool> m_readyForData;
 	std::thread		*m_background;
 	bool			m_init;
 	std::map<std::string, struct timeval>
@@ -157,7 +159,8 @@ class OPCUA
 	enum {
 		ASSET_NAME_SINGLE, ASSET_NAME_SINGLE_OBJ, ASSET_NAME_OBJECT, ASSET_NAME
 				} m_assetNaming;
-	std::map<std::string, std::string>
+	std::set<Node *> m_nodeObjects;
+    std::map<std::string, std::string>
 				m_parents;	// Map variable node id to parent node id
 	std::map<std::string, Node *>
 				m_parentNodes;

--- a/include/opcua.h
+++ b/include/opcua.h
@@ -48,7 +48,8 @@ class OPCUA
     public:
         OPCUA();
         ~OPCUA();
-        void        clear();
+        void        clearConfig();
+        void        clearData();
         void        parseConfig(ConfigCategory &config);
         void        reconfigure(ConfigCategory &config);
         void        clearSubscription();

--- a/opcua.cpp
+++ b/opcua.cpp
@@ -994,7 +994,20 @@ void OPCUA::getNodeFullPath(const std::string &nodeId, std::string &path)
 void OPCUA::start()
 {
 	int n_subscriptions = 0;
-	SOPC_ClientHelper_Security security;
+	SOPC_ClientHelper_Security security = {
+		.security_policy = SOPC_SecurityPolicy_None_URI,
+		.security_mode = OpcUa_MessageSecurityMode_None,
+		.path_cert_auth = NULL,
+		.path_crl = NULL,
+		.path_cert_srv = NULL,
+		.path_cert_cli = NULL,
+		.path_key_cli = NULL,
+		.policyId = "anonymous",
+		.username = NULL,
+		.password = NULL,
+		.path_cert_x509_token = NULL,
+		.path_key_x509_token = NULL,
+	};
 	Logger *logger = Logger::getLogger();
 
 	logger->debug("Calling OPCUA::start");
@@ -1284,7 +1297,13 @@ void OPCUA::start()
 
 	if (configOK && matched)
 	{
-		m_configurationId = SOPC_ClientHelper_CreateConfiguration(m_url.c_str(), &security, NULL);
+		SOPC_ClientHelper_EndpointConnection endPointConnection =
+		{
+			.endpointUrl = m_url.c_str(),
+			.serverUri = NULL,
+			.reverseConnectionConfigId = 0
+		};
+		m_configurationId = SOPC_ClientHelper_CreateConfiguration(&endPointConnection, &security, NULL);
 		logger->debug("ConfigurationId: %d", (int)m_configurationId);
 		if (m_configurationId <= 0)
 		{
@@ -1447,7 +1466,13 @@ SOPC_ClientHelper_GetEndpointsResult *OPCUA::GetEndPoints(const char *endPointUr
 	SOPC_ClientHelper_GetEndpointsResult *endpoints = NULL;
 	try
 	{
-		int res = SOPC_ClientHelper_GetEndpoints(endPointUrl, &endpoints);
+		SOPC_ClientHelper_EndpointConnection endPointConnection =
+		{
+			.endpointUrl = endPointUrl,
+			.serverUri = NULL,
+			.reverseConnectionConfigId = 0
+		};
+		int res = SOPC_ClientHelper_GetEndpoints(&endPointConnection, &endpoints);
 		if ((res == 0) && (endpoints != NULL))
 		{
 			logger->debug("OPC/UA Server has %d endpoints\n", endpoints->nbOfEndpoints);

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -60,8 +60,8 @@ static const char *default_config = QUOTE({
     "reportingInterval" : {
             "description" : "The minimum reporting interval for data change notifications" ,
             "type" : "integer",
-            "default" : "1000",
-	    "minimum" : "100",
+            "default" : "0",
+	    "minimum" : "0",
             "displayName" : "Min Reporting Interval (millisec)",
             "order" : "5"
             },

--- a/requirements.sh
+++ b/requirements.sh
@@ -55,7 +55,7 @@ tar xf check-0.15.2.tar.gz
 )
 
 # S2OPC
-git clone https://gitlab.com/systerel/S2OPC.git --branch S2OPC_Toolkit_1.2.0 --depth 1
+git clone https://gitlab.com/systerel/S2OPC.git --branch S2OPC_Toolkit_1.4.1 --depth 1
 (
 	cd S2OPC
 	cp ../S2OPC.patch .


### PR DESCRIPTION
The S2OPCUA South plugin would fail if large numbers of NodeIds were signed up as Monitored Items. The problem was reported for 10,000 Monitored Items. The Monitored Item problem was reported to Systerel as [Issue 1216](https://gitlab.com/systerel/S2OPC/-/issues/1216). On the advice of Systerel, the plugin was upgraded from _S2OPC_Toolkit_1.2.0_ to _S2OPC_Toolkit_1.4.1_ in order to apply their recommended patches. The patches will be released in _S2OPC_Toolkit_1.5.0_.

Other fixes:
- The S2OPC Toolkit _TimeoutHint_ was set to zero (infinite wait) to avoid disconnection errors in a customer environment.
- The _Minimum Reporting Interval_ minimum value was changed from 100 milliseconds to zero. The default is also set to zero. This effectively makes the feature "opt-in."
- Fixed reconnection logic if connection to the OPC UA server is lost and then restored.