### PR TITLE
FOGL-8449: document Security Policy requirements for username authentication

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,8 @@ The OPC UA Security tab contains a set of configuration items that is used for s
   - **User Authentication Policy**: Specify the user authentication policy that will be used when authenticating the connection to the OPC/UA server.
 
   - **Username**: Specify the username to use for authentication. This is only used if the *User authentication policy* is set to *username*.
+    If you choose this policy, you must select a Security Policy other than None.
+    See the section Username Authentication below.
 
   - **Password**: Specify the password to use for authentication. This is only used if the *User authentication policy* is set to *username*.
 
@@ -188,6 +190,31 @@ We subscribe to
  - Random.Double and Random.Boolean are variables under ObjectsNode/Demo both in namespace 2
 
 Object names, variable names and namespace indices can be easily retrieved browsing the given OPC/UA server using OPC UA clients, such as |UaExpert|.
+
+Username Authentication
+-----------------------
+
+If you set the User Authentication Policy to username, you must select a Security Policy other than *None* to communicate with the OPC/UA Server.
+Allowing *username* with *None* would mean that usernames and passwords would be passed from the plugin to the server as clear text which is a serious security risk.
+This is explained in the `OPC UA Specification Part 4, Section 7.36.4 <https://reference.opcfoundation.org/Core/Part4/v104/docs/7.36.4>`_.
+
+Each OPC/UA server endpoint includes a list of UserIdentityTokens it will accept such as anonymous, username or certificate.
+Each UserIdentityToken has its own Security Policy.
+The S2OPC South plugin requires the configured Security Policy for the connection to match the Security Policy for the UserIdentityToken.
+
+If your configuration fails to find a matching endpoint, it could be because the required UserIdentityToken Security Policy does not match your configuration.
+To diagnose this, set the Minimum Log Level to *Debug* in the Advanced Configuration page of the Fledge GUI.
+After starting the plugin, you will see Debug messages documenting the endpoint search.
+If Security Policy mismatch is the problem, you will see a message like:
+
+.. code-block:: bash
+
+   DEBUG: 0: Security Policy mismatch: Endpoint: 'http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256' UserIdentityToken: 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' (username_basic256)(1)
+
+This message says that the configured Security Policy for the connection is *Basic256Sha256* but the required policy for the UserIdentityToken is *Basic256*.
+To fix this, set the Security Policy for the connection to *Basic256* in the Fledge GUI.
+The string *username_basic256* in this example is the OPC/UA server's name for the UserIdentityToken.
+This name does not affect configuration.
 
 Certificate Management
 ----------------------

--- a/opcua.cpp
+++ b/opcua.cpp
@@ -1422,12 +1422,13 @@ void OPCUA::start()
 					if (matchedPolicyId)
 					{
 						security.policyId = userIds[j].policyId; // Policy Id must match the OPC UA server's name for it
-						logger->debug("Endpoint %d matches on policyId %s (%d)", i, security.policyId, (int)userIds[j].tokenType);
+						logger->debug("Endpoint %d matches on PolicyId '%s' (%s)(%d)", i, security.policyId, userIds[j].securityPolicyUri, (int)userIds[j].tokenType);
 						matched = true;
 					}
 					else
 					{
-						logger->debug("%d: '%s' != '%s' (%d)", i, security.policyId, userIds[j].policyId, (int)userIds[j].tokenType);
+						logger->debug("%d: Security Policy mismatch: Endpoint: '%s' UserIdentityToken: '%s' (%s)(%d)",
+							i, security.security_policy, userIds[j].securityPolicyUri, userIds[j].policyId, (int)userIds[j].tokenType);
 						continue;
 					}
 				}


### PR DESCRIPTION
This work is in response to [User Issue #1272 posted on GitHub](https://github.com/fledge-iot/fledge/issues/1272). The user requested support for username authentication with an OPC UA Security Policy of None. The [S2OPC OPCUA Toolkit](https://systerel.gitlab.io/S2OPC/index.html) does not support this because it is a severe security risk. To partially address this, debug messages for the endpoint search have been improved to show potential problems more clearly. Documentation has been added on how to configure and troubleshoot username authentication.