### PR TITLE
FOGL-8538: Remove quotes from PLUGIN_NAME

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -32,7 +32,7 @@ static const char *default_config = QUOTE({
         "plugin" : {
                 "description" : "Safe & Secure OPC UA data change plugin",
                 "type" : "string",
-                "default" : "PLUGIN_NAME",
+                "default" : PLUGIN_NAME,
                 "readonly" : "true"
         },
         "asset" : {


### PR DESCRIPTION
A bug was inadvertently added to _plugin.cpp_ in the [previous commit](https://github.com/fledge-iot/fledge-south-s2opcua/pull/65). The result is that existing configurations of _fledge-south-s2opcua_ worked properly but no new configurations could be created. This has been fixed.