### PR TITLE
FOGL-8950: Update S2OPC Toolkit message encoding parameter

### DIFF
--- a/include/opcua.h
+++ b/include/opcua.h
@@ -127,6 +127,7 @@ class OPCUA
         int         		subscribe();
 	SOPC_ReturnStatus	initializeS2sdk(const char *traceFilePath);
 	void				uninitializeS2sdk();
+	bool				updateS2parameters();
 	SOPC_ReturnStatus	createS2Subscription();
 	SOPC_ReturnStatus	deleteS2Subscription();
 	SOPC_ReturnStatus	createS2MonitoredItems(char *const *nodeIds, const size_t numNodeIds, bool logRevisions, size_t *numErrors);


### PR DESCRIPTION
The S2OPC Toolkit default value for maximum number of message chunks to accept in an OPC UA service response (_receive_max_nb_chunks_) is too low. The default value is 5. This turns out to be too low for OPC UA servers on distant or noisy networks that break TCP messages into many smaller chunks. Solution is to double this limit to 10.

This problem was exposed by running the [Prosys OPC UA Simulation Server](https://prosysopc.com/products/opc-ua-simulation-server/) on a Windows machine hosted in AWS. The problem did not occur with the same Prosys Simulation Server running on other Windows machines. On the problem server, [Wireshark](https://www.wireshark.org/) showed the chunk count for the _CreateSessionResponse_ was 6 which exceeds the S2OPC Toolkit default limit causing the Toolkit to return a Service Result 0x80800000 (_OpcUa_BadTcpMessageTooLarge_). Other server instances generally returned 3 message chunks for the same service.